### PR TITLE
Use clusterName instead of environment to target cluster configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [Unreleased]
+
+### Added
+
+- Added json-schema to validate config files
+
+### Changed
+
+- Config is now parsed based on `clusterName` instead of `environment` for flexibility
+
+
+
 ## [0.2.0] - 2021-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ USAGE
   $ ecsx config
 
 OPTIONS
-  -e, --environment=environment
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
   --var=var                      [default: ]
 ```
@@ -62,7 +62,7 @@ USAGE
   $ ecsx create-service [TASK]
 
 OPTIONS
-  -e, --environment=environment  (required)
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
   -r, --revision=revision        [default: LATEST]
   --var=var                      [default: ]
@@ -82,7 +82,7 @@ USAGE
   $ ecsx deploy [TASK]
 
 OPTIONS
-  -e, --environment=environment  (required)
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
   -t, --dockerTag=dockerTag      (required)
   --var=var                      [default: ]
@@ -119,7 +119,7 @@ USAGE
   $ ecsx register-task-definition [TASK]
 
 OPTIONS
-  -e, --environment=environment  (required)
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
   -t, --dockerTag=dockerTag      (required)
   --var=var                      [default: ]
@@ -139,7 +139,7 @@ USAGE
   $ ecsx run [TASK]
 
 OPTIONS
-  -e, --environment=environment  (required)
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
   -t, --dockerTag=dockerTag      (required)
   --var=var                      [default: ]
@@ -159,7 +159,7 @@ USAGE
   $ ecsx scale [TASK] [COUNT]
 
 OPTIONS
-  -e, --environment=environment  (required)
+  -c, --clusterName=clusterName  (required)
   -h, --help                     show CLI help
 
 EXAMPLE

--- a/schema.json
+++ b/schema.json
@@ -32,8 +32,10 @@
       "type": "object",
       "additionalProperties": {
         "type": "object",
+        "description": "The key must be the cluster name inside the AWS API",
         "additionalProperties": false,
         "required": [
+          "environment",
           "targetGroups",
           "privateSubnets",
           "publicSubnets",
@@ -41,6 +43,11 @@
           "securityGroups"
         ],
         "properties": {
+          "environment": {
+            "type": "string",
+            "description": "Application environment for containers. This will be available $environment variabe",
+            "example": "production"
+          },
           "targetGroups": {
             "type": "array",
             "items": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,18 +1,17 @@
 /* eslint-disable no-warning-comments */
 import Command from '@oclif/command'
-import { Config } from './config'
 
 import { client } from './ecs/client'
-import { Variables } from './types/configuration'
+import { ClusterVariables } from './types/configuration'
+import { configWithVariables } from './utils/config-with-variables'
 
 export class AwsCommand extends Command {
-  configWithVariables(variables: Variables = {}) {
+  configWithVariables(variables: ClusterVariables) {
     const initialVariables = {
       ...this.variables(),
       ...variables,
     }
-    const configParser = new Config()
-    return configParser.parse(initialVariables)
+    return configWithVariables(initialVariables)
   }
 
   ecs_client() {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -10,15 +10,16 @@ export default class Config extends AwsCommand {
       multiple: true,
       default: [],
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
+      required: true,
     }),
   }
 
   async run() {
-    const { flags: { environment } } = this.parse(Config)
+    const { flags: { clusterName } } = this.parse(Config)
     const { config, variables } = this.configWithVariables({
-      environment,
+      clusterName,
     })
     this.log(JSON.stringify(variables, undefined, 2))
     this.log(JSON.stringify(config, undefined, 2))

--- a/src/commands/create-service.ts
+++ b/src/commands/create-service.ts
@@ -17,8 +17,8 @@ export default class CreateServiceCommand extends AwsCommand {
       multiple: true,
       default: [],
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
       required: true,
     }),
     revision: flags.string({
@@ -35,10 +35,10 @@ export default class CreateServiceCommand extends AwsCommand {
   ]
 
   async run() {
-    const { args: { task }, flags: { environment, revision } } = this.parse(CreateServiceCommand)
+    const { args: { task }, flags: { clusterName, revision } } = this.parse(CreateServiceCommand)
     const client = this.ecs_client()
-    const { config, variables } = this.configWithVariables()
-    const { project, region } = variables
+    const { config, variables } = this.configWithVariables({ clusterName })
+    const { environment, project, region } = variables
 
     // // Generate task definition input and send request to AWS API
     const serviceInput = serviceFromConfiguration({

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -16,8 +16,8 @@ export default class DeployCommand extends AwsCommand {
       multiple: true,
       default: [],
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
       required: true,
     }),
     dockerTag: flags.string({
@@ -34,13 +34,15 @@ export default class DeployCommand extends AwsCommand {
   ]
 
   async run() {
-    const { args: { task }, flags: { environment, dockerTag } } = this.parse(DeployCommand)
     const client = this.ecs_client()
+    const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(DeployCommand)
+    const cluster = await client.describeCluster(clusterName)
+    global.console.log({ cluster })
     const { config, variables } = this.configWithVariables({
-      environment,
+      clusterName,
       dockerTag,
     })
-    const { project, region } = variables
+    const { environment, project, region } = variables
 
     // Generate Task Definition
     const taskDefinitionInput = taskDefinitionfromConfiguration({

--- a/src/commands/register-task-definition.ts
+++ b/src/commands/register-task-definition.ts
@@ -15,8 +15,8 @@ export default class RegisterTaskDefinitionCommand extends AwsCommand {
       multiple: true,
       default: [],
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
       required: true,
     }),
     dockerTag: flags.string({
@@ -33,11 +33,11 @@ export default class RegisterTaskDefinitionCommand extends AwsCommand {
   ]
 
   async run() {
-    const { args: { task }, flags: { environment, dockerTag } } = this.parse(RegisterTaskDefinitionCommand)
+    const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(RegisterTaskDefinitionCommand)
     const client = this.ecs_client()
     const { config, variables } = this.configWithVariables({
+      clusterName,
       dockerTag,
-      environment,
     })
 
     // Generate task definition input and send request to AWS API

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -16,8 +16,8 @@ export default class RunCommand extends AwsCommand {
       multiple: true,
       default: [],
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
       required: true,
     }),
     dockerTag: flags.string({
@@ -34,13 +34,13 @@ export default class RunCommand extends AwsCommand {
   ]
 
   async run() {
-    const { args: { task }, flags: { environment, dockerTag } } = this.parse(RunCommand)
+    const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(RunCommand)
     const client = this.ecs_client()
     const { config, variables } = this.configWithVariables({
-      environment,
+      clusterName,
       dockerTag,
     })
-    const { accountId, project, region } = variables
+    const { accountId, environment, project, region } = variables
 
     // Generate Task Definition
     const taskDefinitionInput = taskDefinitionfromConfiguration({

--- a/src/commands/scale.ts
+++ b/src/commands/scale.ts
@@ -12,8 +12,8 @@ export default class DeployCommand extends AwsCommand {
     help: flags.help({
       char: 'h',
     }),
-    environment: flags.string({
-      char: 'e',
+    clusterName: flags.string({
+      char: 'c',
       required: true,
     }),
   }
@@ -30,10 +30,10 @@ export default class DeployCommand extends AwsCommand {
   ]
 
   async run() {
-    const { args: { task, count }, flags: { environment } } = this.parse(DeployCommand)
+    const { args: { task, count }, flags: { clusterName } } = this.parse(DeployCommand)
     const client = this.ecs_client()
-    const { variables: { project, region } } = this.configWithVariables({
-      environment,
+    const { variables: { environment, project, region } } = this.configWithVariables({
+      clusterName,
     })
 
     // Find running service matching task name

--- a/src/ecs/client.ts
+++ b/src/ecs/client.ts
@@ -1,4 +1,4 @@
-import { CreateServiceCommand, CreateServiceCommandInput, DescribeServicesCommand, DescribeServicesCommandInput, ECSClient, ListTaskDefinitionsCommand, RegisterTaskDefinitionCommand, RegisterTaskDefinitionCommandInput, RunTaskCommand, RunTaskCommandInput, UpdateServiceCommand, UpdateServiceCommandInput } from '@aws-sdk/client-ecs'
+import { CreateServiceCommand, CreateServiceCommandInput, DescribeClustersCommand, DescribeClustersCommandInput, DescribeServicesCommand, DescribeServicesCommandInput, ECSClient, ListTaskDefinitionsCommand, RegisterTaskDefinitionCommand, RegisterTaskDefinitionCommandInput, RunTaskCommand, RunTaskCommandInput, UpdateServiceCommand, UpdateServiceCommandInput } from '@aws-sdk/client-ecs'
 
 export const AWS_REGION = process.env.AWS_REGION || 'eu-central-1'
 
@@ -32,6 +32,21 @@ export const runTask = (params: RunTaskCommandInput) => {
   return ecsClient.send(command)
 }
 
+export const describeClusters = (params: DescribeClustersCommandInput) => {
+  const command = new DescribeClustersCommand(params)
+  return ecsClient.send(command)
+}
+
+export const describeCluster = async (clusterName: string) => {
+  const clusters = await describeClusters({
+    clusters: [
+      clusterName,
+    ],
+  })
+
+  return clusters.clusters && clusters.clusters[0]
+}
+
 export const describeServices = (params: DescribeServicesCommandInput) => {
   const command = new DescribeServicesCommand(params)
   return ecsClient.send(command)
@@ -40,6 +55,8 @@ export const describeServices = (params: DescribeServicesCommandInput) => {
 export const client = {
   region: AWS_REGION,
   createService,
+  describeCluster,
+  describeClusters,
   describeServices,
   listTaskDefinitions,
   registerTaskDefinition,

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -12,9 +12,9 @@ const environmentFromConfiguration = (config: ConfigurationTaskDefinition) => {
   ))
 }
 
-export const secretsFromConfiguration = (task: string, environment: string, config: Configuration) => {
+export const secretsFromConfiguration = (task: string, clusterName: string, config: Configuration) => {
   const taskConfig = config.tasks[task]
-  const clusterConfig = config.clusters[environment]
+  const clusterConfig = config.clusters[clusterName]
   return flatten(taskConfig.secrets.map(entry => {
     const arn = clusterConfig.secrets[entry.name]
     return entry.keys.map(key => {

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -25,9 +25,15 @@ export interface Variables {
   [key: string]: string | undefined
 }
 
+export interface ClusterVariables {
+  clusterName: string
+  [key: string]: string
+}
+
 export interface ConfiguredVariables extends Variables {
+  clusterName: string // should be passed in via CLI flags
+  environment: string // defined via cluster config
   project: string
-  environment: string
   accountId: string
   region: string
 }
@@ -39,7 +45,8 @@ export interface Configuration {
   project: string
   variables: Variables
   clusters: {
-    [environment: string]: {
+    [clusterName: string]: {
+      environment: string
       targetGroups: Array<{
         arn: string
         task: string

--- a/src/utils/config-with-variables.ts
+++ b/src/utils/config-with-variables.ts
@@ -1,0 +1,7 @@
+import { Config } from '../config'
+import { ClusterVariables } from '../types/configuration'
+
+export const configWithVariables = (variables: ClusterVariables) => {
+  const configParser = new Config()
+  return configParser.parse(variables)
+}

--- a/src/utils/variables-from-cluster.ts
+++ b/src/utils/variables-from-cluster.ts
@@ -1,0 +1,8 @@
+import { Configuration } from '../types/configuration'
+
+export const variablesFromCluster = (clusterName: string, config: Configuration) => {
+  const clusterConfig = config.clusters[clusterName] || {}
+  return {
+    environment: clusterConfig.environment,
+  }
+}

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -1,0 +1,23 @@
+process.env.ECSX_CONFIG_PATH = './test/ecsx.yml'
+
+import { describe } from 'mocha'
+import { expect } from 'chai'
+
+import { configWithVariables } from '../src/utils/config-with-variables'
+
+describe('ecs', () => {
+  describe('utils', () => {
+    describe('configWithVariables', () => {
+      it('translate secrets to task definition format', () => {
+        const { variables } = configWithVariables({ clusterName: 'ecsx-test-cluster' })
+        expect(variables).to.deep.equal({
+          clusterName: 'ecsx-test-cluster',
+          environment: 'test',
+          project: 'ecsx',
+          region: 'us-east-1',
+          accountId: 1234,
+        })
+      })
+    })
+  })
+})

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -4,9 +4,9 @@ describe('command', () => {
   describe('config', () => {
     test
     .stdout()
-    .command(['config'])
+    .command(['config', '-c', 'test-cluster'])
     .it('sets the correct region', ctx => {
-      expect(ctx.stdout).to.contain('"region": "eu-central-1",')
+      expect(ctx.stdout).to.contain('"region": "us-east-1",')
     })
   })
 })

--- a/test/ecs/task-definition.test.ts
+++ b/test/ecs/task-definition.test.ts
@@ -1,60 +1,25 @@
+process.env.ECSX_CONFIG_PATH = './test/ecsx.yml'
+
 import { describe } from 'mocha'
 import { expect } from 'chai'
 
-import { Configuration } from '../../src/types/configuration'
 import { secretsFromConfiguration } from '../../src/ecs/task-definition'
-
-const mockConfig: Configuration = {
-  version: '0.1',
-  region: 'us-east-1',
-  accountId: 'act-xxx',
-  project: 'test',
-  variables: {},
-  clusters: {
-    test: {
-      secrets: {
-        app: 'arn:123:app/test-xxx',
-      },
-      targetGroups: [],
-      securityGroups: [],
-      publicSubnets: [],
-      privateSubnets: [],
-    },
-  },
-  tasks: {
-    mocha: {
-      image: '',
-      command: [],
-      cpu: 256,
-      memory: 512,
-      environment: {},
-      executionRoleArn: 'role-1',
-      secrets: [
-        {
-          name: 'app',
-          keys: [
-            'NODE_ENV',
-            'SOME_VAR',
-          ],
-        },
-      ],
-    },
-  },
-}
+import { configWithVariables } from '../../src/utils/config-with-variables'
 
 describe('ecs', () => {
   describe('task-definition', () => {
     describe('secretsFromConfiguration', () => {
       it('translate secrets to task definition format', () => {
-        const output = secretsFromConfiguration('mocha', 'test', mockConfig)
+        const { config } = configWithVariables({ clusterName: 'ecsx-test-cluster' })
+        const output = secretsFromConfiguration('mocha', 'ecsx-test-cluster', config)
         expect(output).to.deep.equal([
           {
             name: 'NODE_ENV',
-            valueFrom: 'arn:123:app/test-xxx:NODE_ENV::',
+            valueFrom: 'arn:aws:secretsmanager:us-east-1:1234:secret:ecsx/app/test-xxx:NODE_ENV::',
           },
           {
             name: 'SOME_VAR',
-            valueFrom: 'arn:123:app/test-xxx:SOME_VAR::',
+            valueFrom: 'arn:aws:secretsmanager:us-east-1:1234:secret:ecsx/app/test-xxx:SOME_VAR::',
           },
         ])
       })

--- a/test/ecsx.yml
+++ b/test/ecsx.yml
@@ -1,0 +1,36 @@
+version: 0.1
+
+region: 'us-east-1'
+accountId: 1234
+project: 'ecsx'
+
+clusters:
+  ecsx-test-cluster:
+    environment: test
+    targetGroups:
+      - arn: arn:xxx
+        port: 3000
+        task: mocha
+    securityGroups:
+      - "sg-1"
+    publicSubnets:
+      - "subnet-1"
+    privateSubnets:
+      - "subnet-2"
+    secrets:
+      app: arn:aws:secretsmanager:{{ region }}:{{ accountId }}:secret:{{ project }}/app/test-xxx
+
+tasks:
+  mocha:
+    taskRoleArn: 'somerole'
+    executionRoleArn: 'somerole'
+    image: ''
+    command: []
+    cpu: 256
+    memory: 512
+    environment: {}
+    secrets:
+      - name: 'app'
+        keys:
+          - NODE_ENV
+          - SOME_VAR

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
+    "rootDir": "../",
     "noEmit": true
   },
-  "include": [
-    "**/*.test.ts"
-  ],
   "references": [
     {
       "path": ".."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "target": "es2017"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "test/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This allows any number of cluster, even sharing the same app environment, to be referenced with their own config.