### PR TITLE
Fix environment from envVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [Unreleased]
+
+### Fixed
+
+- New `envVars` weren't actually being passed through to docker containers
+
+
+
 ## [0.4.1] - 2021-06-02
 
 ### Added

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -63,7 +63,7 @@ export default class ConsoleCommand extends AwsCommand {
 
     const taskInput = taskFromConfiguration({
       clusterName,
-      task: consoleTask,
+      taskName: consoleTask,
       alias: 'console',
       revision,
       variables,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -24,7 +24,7 @@ export default class DeployCommand extends AwsCommand {
 
   static args = [
     {
-      name: 'task',
+      name: 'taskName',
       type: 'string',
       required: true,
     },
@@ -32,9 +32,10 @@ export default class DeployCommand extends AwsCommand {
 
   async run() {
     const client = this.ecs_client()
-    const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(DeployCommand)
+    const { args: { taskName }, flags: { clusterName, dockerTag } } = this.parse(DeployCommand)
     const { config, variables, envVars } = this.configWithVariables({
       clusterName,
+      taskName,
       dockerTag,
     })
     const { environment, project, region } = variables
@@ -42,7 +43,7 @@ export default class DeployCommand extends AwsCommand {
     // Generate Task Definition
     const taskDefinitionInput = taskDefinitionfromConfiguration({
       clusterName,
-      task,
+      taskName,
       variables,
       config,
       envVars,
@@ -57,7 +58,7 @@ export default class DeployCommand extends AwsCommand {
     // NOTE: Inactive services need to created again, rather than updated
     const serviceInput = serviceFromConfiguration({
       clusterName,
-      task,
+      taskName,
       revision: taskDefinition.revision?.toString() || '',
       variables,
       config,
@@ -82,7 +83,7 @@ export default class DeployCommand extends AwsCommand {
       this.log(JSON.stringify({
         serviceArn: service.serviceArn,
         taskDefinitionArn: taskDefinition.taskDefinitionArn,
-        url: `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${project}-${environment}/services/${task}/health?region=${region}`,
+        url: `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${project}-${environment}/services/${taskName}/health?region=${region}`,
       }, undefined, 2))
     // Update existing service
     } else {
@@ -100,7 +101,7 @@ export default class DeployCommand extends AwsCommand {
       this.log(JSON.stringify({
         serviceArn: service.serviceArn,
         taskDefinitionArn: taskDefinition.taskDefinitionArn,
-        url: `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${project}-${environment}/services/${task}/health?region=${region}`,
+        url: `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${project}-${environment}/services/${taskName}/health?region=${region}`,
       }, undefined, 2))
     }
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -33,7 +33,7 @@ export default class DeployCommand extends AwsCommand {
   async run() {
     const client = this.ecs_client()
     const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(DeployCommand)
-    const { config, variables } = this.configWithVariables({
+    const { config, variables, envVars } = this.configWithVariables({
       clusterName,
       dockerTag,
     })
@@ -45,6 +45,7 @@ export default class DeployCommand extends AwsCommand {
       task,
       variables,
       config,
+      envVars,
     })
     const taskDefinitionResponse = await client.registerTaskDefinition(taskDefinitionInput)
     const { taskDefinition } = taskDefinitionResponse

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -33,7 +33,7 @@ export default class RunCommand extends AwsCommand {
   async run() {
     const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(RunCommand)
     const client = this.ecs_client()
-    const { config, variables } = this.configWithVariables({
+    const { config, variables, envVars } = this.configWithVariables({
       clusterName,
       dockerTag,
     })
@@ -45,6 +45,7 @@ export default class RunCommand extends AwsCommand {
       task,
       variables,
       config,
+      envVars,
     })
     const taskDefinitionResponse = await client.registerTaskDefinition(taskDefinitionInput)
     const { taskDefinition } = taskDefinitionResponse

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -24,14 +24,14 @@ export default class RunCommand extends AwsCommand {
 
   static args = [
     {
-      name: 'task',
+      name: 'taskName',
       type: 'string',
       required: true,
     },
   ]
 
   async run() {
-    const { args: { task }, flags: { clusterName, dockerTag } } = this.parse(RunCommand)
+    const { args: { taskName }, flags: { clusterName, dockerTag } } = this.parse(RunCommand)
     const client = this.ecs_client()
     const { config, variables, envVars } = this.configWithVariables({
       clusterName,
@@ -42,7 +42,7 @@ export default class RunCommand extends AwsCommand {
     // Generate Task Definition
     const taskDefinitionInput = taskDefinitionfromConfiguration({
       clusterName,
-      task,
+      taskName,
       variables,
       config,
       envVars,
@@ -56,7 +56,7 @@ export default class RunCommand extends AwsCommand {
     // Run task using created definition
     const taskInput = taskFromConfiguration({
       clusterName,
-      task,
+      taskName,
       revision: taskDefinition.revision?.toString() || '',
       variables,
       config,

--- a/src/ecs/service.ts
+++ b/src/ecs/service.ts
@@ -4,14 +4,14 @@ import { Configuration, ConfiguredVariables } from '../types/configuration'
 
 interface Params {
   clusterName: string
-  task: string
+  taskName: string
   revision: string
   variables: ConfiguredVariables
   config: Configuration
 }
 
 export const serviceFromConfiguration = (params: Params): CreateServiceCommandInput => {
-  const { clusterName, task, revision, variables, config } = params
+  const { clusterName, taskName, revision, variables, config } = params
   const { project, environment } = variables
 
   const clusterConfig = config.clusters[clusterName]
@@ -20,12 +20,12 @@ export const serviceFromConfiguration = (params: Params): CreateServiceCommandIn
   const securityGroups = clusterConfig.securityGroups
 
   return {
-    serviceName: task,
+    serviceName: taskName,
     cluster: clusterName,
-    taskDefinition: `${project}-${task}-${environment}:${revision}`,
+    taskDefinition: `${project}-${taskName}-${environment}:${revision}`,
     desiredCount: 1,
     launchType: 'FARGATE',
-    loadBalancers: targetGroups.filter(targetGroup => targetGroup.task === task).map(targetGroup => ({
+    loadBalancers: targetGroups.filter(targetGroup => targetGroup.task === taskName).map(targetGroup => ({
       containerName: targetGroup.task,
       containerPort: targetGroup.port,
       targetGroupArn: targetGroup.arn,

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -1,10 +1,10 @@
 import { RegisterTaskDefinitionCommandInput } from '@aws-sdk/client-ecs'
 import flatten from 'lodash/flatten'
 
-import { Configuration, ConfigurationTaskDefinition, ConfiguredVariables } from '../types/configuration'
+import { Configuration, ConfigurationTaskDefinition, ConfiguredVariables, KeyValuePairs } from '../types/configuration'
 
-const environmentFromConfiguration = (config: ConfigurationTaskDefinition) => {
-  return Object.entries(config.environment || {}).map(([key, value]) => (
+const environmentFromEnvVars = (envVars: KeyValuePairs) => {
+  return Object.entries(envVars).map(([key, value]) => (
     {
       name: key,
       value,
@@ -54,10 +54,11 @@ interface Params {
   task: string
   variables: ConfiguredVariables
   config: Configuration
+  envVars: KeyValuePairs
 }
 
 export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {
-  const { clusterName, task, variables, config } = params
+  const { clusterName, task, variables, config, envVars } = params
   const { project, environment } = variables
   const taskConfig = config.tasks[task]
 
@@ -77,7 +78,7 @@ export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDef
         image: taskConfig.image,
         command: taskConfig.command,
         portMappings: portMappingsFromConfiguration(taskConfig),
-        environment: environmentFromConfiguration(taskConfig),
+        environment: environmentFromEnvVars(envVars),
         secrets: secretsFromConfiguration(task, clusterName, config),
         logConfiguration: logConfigurationFromConfiguration(task, variables),
         essential: true,

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -51,19 +51,19 @@ const logConfigurationFromConfiguration = (task: string, variables: ConfiguredVa
 
 interface Params {
   clusterName: string
-  task: string
+  taskName: string
   variables: ConfiguredVariables
   config: Configuration
   envVars: KeyValuePairs
 }
 
 export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDefinitionCommandInput => {
-  const { clusterName, task, variables, config, envVars } = params
+  const { clusterName, taskName, variables, config, envVars } = params
   const { project, environment } = variables
-  const taskConfig = config.tasks[task]
+  const taskConfig = config.tasks[taskName]
 
   return {
-    family: `${project}-${task}-${environment}`,
+    family: `${project}-${taskName}-${environment}`,
     taskRoleArn: taskConfig.taskRoleArn,
     executionRoleArn: taskConfig.executionRoleArn,
     networkMode: 'awsvpc',
@@ -74,13 +74,13 @@ export const taskDefinitionfromConfiguration = (params: Params): RegisterTaskDef
     memory: taskConfig.memory.toString(),
     containerDefinitions: [
       {
-        name: task,
+        name: taskName,
         image: taskConfig.image,
         command: taskConfig.command,
         portMappings: portMappingsFromConfiguration(taskConfig),
         environment: environmentFromEnvVars(envVars),
-        secrets: secretsFromConfiguration(task, clusterName, config),
-        logConfiguration: logConfigurationFromConfiguration(task, variables),
+        secrets: secretsFromConfiguration(taskName, clusterName, config),
+        logConfiguration: logConfigurationFromConfiguration(taskName, variables),
         essential: true,
         readonlyRootFilesystem: false,
       },

--- a/src/ecs/task.ts
+++ b/src/ecs/task.ts
@@ -4,7 +4,7 @@ import { Configuration, ConfiguredVariables } from '../types/configuration'
 
 interface Params {
   clusterName: string
-  task: string
+  taskName: string
   revision: string
   variables: ConfiguredVariables
   config: Configuration
@@ -13,7 +13,7 @@ interface Params {
 }
 
 export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
-  const { clusterName, task, revision, variables, config, alias, enableExecuteCommand = false } = params
+  const { clusterName, taskName, revision, variables, config, alias, enableExecuteCommand = false } = params
   const { project, environment } = variables
 
   const clusterConfig = config.clusters[clusterName]
@@ -28,7 +28,7 @@ export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
     return {
       containerOverrides: [
         {
-          name: task,
+          name: taskName,
           command: [
             'sleep',
             '900',
@@ -40,9 +40,9 @@ export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
 
   return {
     cluster: clusterName,
-    taskDefinition: `${project}-${task}-${environment}:${revision}`,
+    taskDefinition: `${project}-${taskName}-${environment}:${revision}`,
     count: 1,
-    group: `task:${alias || task}`,
+    group: `task:${alias || taskName}`,
     launchType: 'FARGATE',
     enableExecuteCommand,
     networkConfiguration: {


### PR DESCRIPTION
EnvVars were generated, but not actually passed to the taskDefinition + containers.

v0.4.1 should be yanked.