### PR TITLE
Extend console duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [Unreleased]
+
+## Changed
+
+- Increase console timeout from 15 minutes to 56 minutes (#34)
+
+
+
 ## [0.4.3] - 2021-06-11
 
 ### Added

--- a/src/ecs/task.ts
+++ b/src/ecs/task.ts
@@ -26,6 +26,8 @@ export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
       return undefined
     }
 
+    // The sleep task keep the container alive for X amount of seconds
+    // Once the sleep is finished, the container is exit gracefully and no longer be billed
     return {
       containerOverrides: [
         {

--- a/src/ecs/task.ts
+++ b/src/ecs/task.ts
@@ -34,7 +34,7 @@ export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
           name: taskName,
           command: [
             'sleep',
-            '900',
+            '3360', // 56 minutes. vCPU units are billed per (partial) hour
           ],
         },
       ],


### PR DESCRIPTION
Extend duration to 56 minutes since we are billed for the whole hour anyways.

Resolves #32 