### PR TITLE
Fix: Pass in task name to generate the env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+## [Unreleased]
+
+### Fixed
+
+- envVars in task config were missed off for one off tasks (#39)
+
+
+
 ## [0.4.4] - 2021-06-16
 
 ### Changed

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -35,6 +35,7 @@ export default class RunCommand extends AwsCommand {
     const client = this.ecs_client()
     const { config, variables, envVars } = this.configWithVariables({
       clusterName,
+      taskName,
       dockerTag,
     })
     const { accountId, environment, project, region } = variables


### PR DESCRIPTION
This resolves the issue where `envVars` are in the task config and not in the cluster config.