### PR TITLE
Standalone console task via convention

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -60,10 +60,6 @@
               "type": "string"
             }
           },
-          "consoleTask": {
-            "type": "string",
-            "description": "Defines which task will be used when starting a console session"
-          },
           "targetGroups": {
             "type": "array",
             "items": {

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -96,8 +96,10 @@ export default class ConsoleCommand extends AwsCommand {
       if (taskDetails === undefined) {
         this.error(`Could not find task details for taskArn "${consoleTask.taskArn}"`)
       }
-      taskStatus = taskDetails.lastStatus
-      cli.action.start('', taskStatus)
+      if (taskStatus !== taskDetails.lastStatus) {
+        taskStatus = taskDetails.lastStatus
+        cli.action.start('', taskStatus)
+      }
     }
     cli.action.stop(taskStatus)
 

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -91,7 +91,7 @@ export default class ConsoleCommand extends AwsCommand {
     let stopCode: string | undefined
     cli.action.start('', taskStatus)
     while (taskStatus === undefined || taskStatus === 'PROVISIONING' || taskStatus === 'PENDING' || taskStatus === 'DEPROVISIONING') {
-      await new Promise(resolve => setTimeout(resolve, 10000))
+      await new Promise(resolve => setTimeout(resolve, 5000))
       taskDetails = await client.describeTask(clusterName, consoleTask.taskArn)
       if (taskDetails === undefined) {
         this.error(`Could not find task details for taskArn "${consoleTask.taskArn}"`)

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -37,9 +37,11 @@ export default class ConsoleCommand extends AwsCommand {
     })
 
     // Ensure there is a console task defined
-    const consoleTask = config.tasks.console
-    if (consoleTask === undefined) {
-      this.error('Could not locale console task in config. Please adjust config then try again')
+    // TODO: If custom console command is specified, definition may not already exist
+    const taskDefinitionName = config.tasks.web ? 'web' : 'console'
+    const consoleTaskConfig = config.tasks.taskDefinitionName
+    if (consoleTaskConfig === undefined) {
+      this.error(`Could not locale "${taskDefinitionName}" task in config. Please adjust config then try again`)
     }
 
     // Find running service matching task name to get the task definition revision
@@ -62,7 +64,7 @@ export default class ConsoleCommand extends AwsCommand {
 
     const taskInput = taskFromConfiguration({
       clusterName,
-      taskName: 'console',
+      taskName: taskDefinitionName,
       alias: 'console',
       revision,
       variables,
@@ -112,7 +114,7 @@ export default class ConsoleCommand extends AwsCommand {
     // To avoid building this into the tool, just use aws cli directly
     this.log('> Ready: Run the the following command to connect to the task')
     this.log(' ')
-    this.log(`$ aws ecs execute-command --cluster ${clusterName} --task ${taskDetails.taskArn} --container console --interactive --command "${command}"`)
+    this.log(`$ aws ecs execute-command --cluster ${clusterName} --task ${taskDetails.taskArn} --container ${taskDefinitionName} --interactive --command "${command}"`)
     this.log(' ')
   }
 }

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -21,7 +21,6 @@ export interface ConfigurationClusterDefinition {
   environment: string
   project?: string
   envVars?: KeyValuePairs
-  consoleTask?: string
   targetGroups: Array<{
     arn: string
     task: string


### PR DESCRIPTION
Since we now set the convention of a `web` task we can use that without any extra `consoleTask` config for all clusters.