### PR TITLE
Group log streams by project + environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Public IPs are off by default, but can be enabled per cluster/task
+- Log groups are now segmened by project + environment, stream prefixed with task name (#49)
 
 ### Removed
 

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -44,9 +44,9 @@ const logConfigurationFromConfiguration = (task: string, variables: ConfiguredVa
     secretOptions: [],
     options: {
       'awslogs-create-group': 'true',
-      'awslogs-group': `/ecs/${variables.project}/${task}`,
+      'awslogs-group': `/ecs/${variables.project}-${variables.environment}`,
       'awslogs-region': variables.region,
-      'awslogs-stream-prefix': `${variables.environment}`,
+      'awslogs-stream-prefix': `${task}`,
     },
   }
 }


### PR DESCRIPTION
This makes filtering much easier in Cloudwatch.