### PR TITLE
Distinguish services + tasks

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -120,7 +120,7 @@
           }
         }
       },
-      "Task": {
+      "Service": {
         "type": "object",
         "additionalProperties": false,
         "required": [
@@ -158,9 +158,92 @@
               "type": "integer"
             }
           },
-          "service": {
+          "schedule": {
+            "type": "string",
+            "descrition": "Runs this task on a specfic schedule"
+          },
+          "assignPublicIp": {
             "type": "boolean",
-            "default": true
+            "default": false,
+            "description": "If true, will assign a public IPv4 address to each container"
+          },
+          "envVars": {
+            "type": "object",
+            "description": "Key/value pairs to populate the system environment variables",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "subnets": {
+            "type": "array",
+            "description": "List of subnets to associate with containers. Can be overriden at the task level.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "secrets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "keys",
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Reference to the cluster secret, which is defined via #/clusters/*/secrets/[name]"
+                },
+                "keys": {
+                  "type": "array",
+                  "description": "List of keys to extract and make available as ENV variables inside task containers",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "executionRoleArn",
+          "image",
+          "taskRoleArn"
+        ],
+        "properties": {
+          "image": {
+            "type": "string",
+            "description": "Docker image to load for this task",
+            "example": "00000000.dkr.ecr.us-east-1.amazonaws.com/myapp:latest"
+          },
+          "taskRoleArn": {
+            "type": "string"
+          },
+          "executionRoleArn": {
+            "type": "string"
+          },
+          "cpu": {
+            "type": "integer"
+          },
+          "memory": {
+            "type": "integer"
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ports": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
           },
           "schedule": {
             "type": "string",

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -35,11 +35,12 @@ export default class ConsoleCommand extends AwsCommand {
     const { config, variables } = this.configWithVariables({
       clusterName,
     })
+    const services = config.services || {}
 
     // Ensure there is a console task defined
     // TODO: If custom console command is specified, definition may not already exist
-    const taskDefinitionName = config.tasks.web ? 'web' : 'console'
-    const consoleTaskConfig = config.tasks[taskDefinitionName]
+    const taskDefinitionName = services.web ? 'web' : 'console'
+    const consoleTaskConfig = services[taskDefinitionName]
     if (consoleTaskConfig === undefined) {
       this.error(`Could not locale "${taskDefinitionName}" task in config. Please adjust config then try again`)
     }

--- a/src/commands/ps.ts
+++ b/src/commands/ps.ts
@@ -50,8 +50,8 @@ export default class PsCommand extends AwsCommand {
     })
 
     // Find all services/tasks defined in local config
-    const configServiceNames = Object.entries(config.services || []).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
-    const configTaskNames = Object.entries(config.tasks || []).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
+    const configServiceNames = Object.entries(config.services || {}).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
+    const configTaskNames = Object.entries(config.tasks || {}).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
 
     // Find services within cluster
     // TODO: Remove tasks where service=false

--- a/src/commands/ps.ts
+++ b/src/commands/ps.ts
@@ -50,8 +50,8 @@ export default class PsCommand extends AwsCommand {
     })
 
     // Find all services/tasks defined in local config
-    const configServiceNames = Object.entries(config.tasks).filter(([taskName, taskConfig]) => !taskName.startsWith('$') && (taskConfig.service === true || taskConfig.service === undefined)).map(([taskName]) => taskName)
-    const configTaskNames = Object.entries(config.tasks).filter(([taskName, taskConfig]) => !taskName.startsWith('$') && taskConfig.service === false).map(([taskName]) => taskName)
+    const configServiceNames = Object.entries(config.services || []).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
+    const configTaskNames = Object.entries(config.tasks || []).filter(([taskName]) => !taskName.startsWith('$')).map(([taskName]) => taskName)
 
     // Find services within cluster
     // TODO: Remove tasks where service=false

--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -13,7 +13,9 @@ const environmentFromEnvVars = (envVars: KeyValuePairs) => {
 }
 
 export const secretsFromConfiguration = (task: string, clusterName: string, config: Configuration) => {
-  const taskConfig = config.tasks[task]
+  const services = config.services || {}
+  const tasks = config.tasks || {}
+  const taskConfig = services[task] || tasks[task]
   const clusterConfig = config.clusters[clusterName]
   const clusterSecrets = clusterConfig.secrets || {}
   const taskSecrets = taskConfig.secrets || []

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,3 +1,20 @@
+export interface ConfigurationServiceDefinition {
+  image: string
+  command?: string[]
+  envVars?: KeyValuePairs
+  cpu: 256 | 512 | 1024 | 2048 | 4096
+  memory: 512 | 1024 | 2048 | 3072 | 4096 | 5120 | 6144 | 7168 | 8192 | 12288 | 16384
+  secrets?: Array<{
+    name: string
+    keys: string[]
+  }>
+  ports?: number[]
+  taskRoleArn?: string
+  executionRoleArn: string
+  subnets?: string[]
+  assignPublicIp?: boolean
+}
+
 export interface ConfigurationTaskDefinition {
   image: string
   command?: string[]
@@ -14,7 +31,6 @@ export interface ConfigurationTaskDefinition {
   executionRoleArn: string
   subnets?: string[]
   assignPublicIp?: boolean
-  service?: boolean
 }
 
 export interface ConfigurationClusterDefinition {
@@ -75,7 +91,10 @@ export interface Configuration {
   clusters: {
     [clusterName: string]: ConfigurationClusterDefinition
   }
-  tasks: {
+  services?: {
+    [name: string]: ConfigurationServiceDefinition
+  }
+  tasks?: {
     [name: string]: ConfigurationTaskDefinition
   }
 }

--- a/test/ecsx.yml
+++ b/test/ecsx.yml
@@ -20,6 +20,25 @@ clusters:
     secrets:
       app: arn:aws:secretsmanager:{{ region }}:{{ accountId }}:secret:{{ project }}/app/test-xxx
 
+services:
+  web:
+    taskRoleArn: 'somerole'
+    executionRoleArn: 'somerole'
+    image: ''
+    command: []
+    cpu: 256
+    memory: 512
+    envVars:
+      APP_ENV: task-test
+      CLUSTER_NAME: "{{ clusterName }}"
+    environment:
+      DEPRECATED_APP_ENV: invalid
+    secrets:
+      - name: 'app'
+        keys:
+          - NODE_ENV
+          - SOME_VAR
+
 tasks:
   mocha:
     taskRoleArn: 'somerole'


### PR DESCRIPTION
Services and tasks should behabe different, and are also deployed differently.

For example:

- `services` use `deploy`
- `services` should stay up, and restart if they fail
- `tasks` use `run`
- `tasks` run for a period of time then exit
- `services` can be `scaled`, but tasks cannot