### PR TITLE
Allow for public/private subnets and IP allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Public IPs are off by default, but can be enabled per cluster/task
+- Configuration synatx for public/private subnets has been updated (#54)
+- Public IPs are allocated by default, but tasks can be spun up in a private subnet (#54)
 - Log groups are now segmened by project + environment, stream prefixed with task name (#49)
-
-### Removed
-
-- No longer provide public/private subnet config
 
 
 

--- a/schema.json
+++ b/schema.json
@@ -35,6 +35,7 @@
         "additionalProperties": false,
         "required": [
           "environment",
+          "subnets",
           "targetGroups",
           "securityGroups"
         ],
@@ -43,11 +44,6 @@
             "type": "string",
             "description": "Application environment for containers. This will be available $environment variabe",
             "example": "production"
-          },
-          "assignPublicIp": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, will assign a public IPv4 address to each container"
           },
           "project": {
             "type": "string",
@@ -58,6 +54,27 @@
             "description": "Key/value pairs to populate the system environment variables",
             "additionalProperties": {
               "type": "string"
+            }
+          },
+          "subnets": {
+            "type": "object",
+            "required": [
+              "private",
+              "public"
+            ],
+            "properties": {
+              "private": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "public": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
           },
           "targetGroups": {
@@ -76,13 +93,6 @@
           "securityGroups": {
             "type": "array",
             "description": "List of security group IDs to associate with containers",
-            "items": {
-              "type": "string"
-            }
-          },
-          "subnets": {
-            "type": "array",
-            "description": "List of subnets to associate with containers. Can be overriden at the task level.",
             "items": {
               "type": "string"
             }
@@ -166,11 +176,6 @@
             "type": "string",
             "descrition": "Runs this task on a specfic schedule"
           },
-          "assignPublicIp": {
-            "type": "boolean",
-            "default": false,
-            "description": "If true, will assign a public IPv4 address to each container"
-          },
           "environment": {
             "type": "object",
             "deprecated": true,
@@ -185,12 +190,14 @@
               "type": "string"
             }
           },
-          "subnets": {
-            "type": "array",
-            "description": "List of subnets to associate with containers. Can be overriden at the task level.",
-            "items": {
-              "type": "string"
-            }
+          "subnet": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "description": "Assigns task to a cluster defined subnet and allocates a publically routabe IP if set to \"public\".",
+            "default": "public"
           },
           "secrets": {
             "type": "array",

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,13 @@ export class Config {
       }
     }
 
+    // Re-parse and apply defaults
+    // TODO: Find a cleaner way of applying all defaults as pre schema.json definitions
     data = yaml.load(content)
+    for (const taskName of Object.keys(data.tasks)) {
+      data.tasks[taskName].subnet = data.tasks[taskName].subnet || 'public'
+    }
+
     return {
       config: data,
       variables: combinedVariables,

--- a/src/ecs/service.ts
+++ b/src/ecs/service.ts
@@ -17,9 +17,10 @@ export const serviceFromConfiguration = (params: Params): CreateServiceCommandIn
   const clusterConfig = config.clusters[clusterName]
   const taskConfig = config.tasks[taskName]
   const targetGroups = clusterConfig.targetGroups
-  const subnets = taskConfig.subnets || clusterConfig.subnets
+  const taskSubnet = taskConfig.subnet
+  const subnets = clusterConfig.subnets[taskSubnet]
   const securityGroups = clusterConfig.securityGroups
-  const assignPublicIp = (clusterConfig.assignPublicIp === undefined ? taskConfig.assignPublicIp : clusterConfig.assignPublicIp) || false
+  const assignPublicIp = taskSubnet === 'public'
 
   return {
     serviceName: taskName,

--- a/src/ecs/task.ts
+++ b/src/ecs/task.ts
@@ -18,9 +18,10 @@ export const taskFromConfiguration = (params: Params): RunTaskCommandInput => {
 
   const clusterConfig = config.clusters[clusterName]
   const taskConfig = config.tasks[taskName]
-  const subnets = taskConfig.subnets || clusterConfig.subnets
+  const taskSubnet = taskConfig.subnet
+  const subnets = clusterConfig.subnets[taskSubnet]
   const securityGroups = clusterConfig.securityGroups
-  const assignPublicIp = (clusterConfig.assignPublicIp === undefined ? taskConfig.assignPublicIp : clusterConfig.assignPublicIp) || false
+  const assignPublicIp = taskSubnet === 'public'
 
   const overrides = (() => {
     if (enableExecuteCommand === false) {

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -12,8 +12,7 @@ export interface ConfigurationTaskDefinition {
   ports?: number[]
   taskRoleArn?: string
   executionRoleArn: string
-  subnets?: string[]
-  assignPublicIp?: boolean
+  subnet: 'public' | 'private'
   service?: boolean
 }
 
@@ -27,8 +26,10 @@ export interface ConfigurationClusterDefinition {
     port: number
   }>
   securityGroups: string[]
-  subnets: string[]
-  assignPublicIp?: boolean
+  subnets: {
+    public: string[]
+    private: string[]
+  }
   secrets?: {
     [name: string]: string
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,8 +15,9 @@ describe('ecs', () => {
         expect(config.region).to.equal('us-east-1')
         expect(config.accountId).to.equal(1234)
 
-        expect(config.clusters['ecsx-test-cluster'].subnets).to.deep.equal(['subnet-1'])
-        expect(config.tasks.mocha.subnets).to.deep.equal(['subnet-2'])
+        expect(config.clusters['ecsx-test-cluster'].subnets).to.deep.equal({ public: ['subnet-1'], private: [] })
+        expect(config.tasks.web.subnet).to.deep.equal('public')
+        expect(config.tasks.mocha.subnet).to.deep.equal('private')
 
         // Verify that variables are processed out
         expect(config.tasks.mocha.envVars?.CLUSTER_NAME).to.equal('ecsx-test-cluster')

--- a/test/ecsx.yml
+++ b/test/ecsx.yml
@@ -16,11 +16,30 @@ clusters:
     securityGroups:
       - "sg-1"
     subnets:
-      - "subnet-1"
+      public: [ subnet-1 ]
+      private: []
     secrets:
       app: arn:aws:secretsmanager:{{ region }}:{{ accountId }}:secret:{{ project }}/app/test-xxx
 
 tasks:
+  web:
+    taskRoleArn: 'somerole'
+    executionRoleArn: 'somerole'
+    image: ''
+    command: []
+    cpu: 256
+    memory: 512
+    service: true
+    envVars:
+      APP_ENV: task-test
+      CLUSTER_NAME: "{{ clusterName }}"
+    environment:
+      DEPRECATED_APP_ENV: invalid
+    secrets:
+      - name: 'app'
+        keys:
+          - NODE_ENV
+          - SOME_VAR
   mocha:
     taskRoleArn: 'somerole'
     executionRoleArn: 'somerole'
@@ -28,13 +47,13 @@ tasks:
     command: []
     cpu: 256
     memory: 512
+    service: false
     envVars:
       APP_ENV: task-test
       CLUSTER_NAME: "{{ clusterName }}"
     environment:
       DEPRECATED_APP_ENV: invalid
-    subnets:
-      - subnet-2
+    subnet: private
     secrets:
       - name: 'app'
         keys:


### PR DESCRIPTION
Resolves #52 

This allows projects to run in public subnets by dfault (easiest setup), but also put into private if needed.

## Existing (public) projects

Task level `subnet` defaults to `public`. Make the following change to cluster config:

```diff
- subnets: [ subnet-1, subnet-2, subnet-3 ]
+ subnets:
+   public: [ subnet-1, subnet-2, subnet-3 ]
+   private: []
```

## Existing (private) projects

Make the following change to cluster config:

```diff
- subnets: [ subnet-1, subnet-2, subnet-3 ]
+ subnets:
+   public: []
+   private: [ subnet-1, subnet-2, subnet-3 ]
```

Then on each task:

```diff
+ subnet: 'private'
```