### PR TITLE
Add siblingContainers and dependsOn options to the task definitions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dbl-works/dev-ops-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dbl-works/dev-ops-admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.8.0-alpha.0]
+## [0.8.0-alpha.1]
 
 
 - Regional cluster support #71
-
+- Add siblingContainers and dependsOn options to the task definitions [dbl-works/#1](https://github.com/dbl-works/ecsx/pull/1)
 
 
 ## [0.7.0] - 2022-05-25

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "posttest": "yarn lint",
     "prepack": "tsc -b --clean && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha -r ts-node/register --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif-dev readme && git add README.md"
+    "version": "oclif-dev readme && git add README.md",
+    "postinstall": "tsc"
   },
   "types": "lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ecsx",
   "description": "Easily create, manage and deploy ECS based applications",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-alpha.1",
   "author": "Marc Qualie @marcqualie",
   "bin": {
     "ecsx": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prepack": "tsc -b --clean && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha -r ts-node/register --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md",
-    "postinstall": "tsc"
+    "postinstall": "tsc || echo done."
   },
   "types": "lib/index.d.ts"
 }

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -1,6 +1,10 @@
 export interface ConfigurationTaskDefinition {
   image: string
   command?: string[]
+  dependsOn?: Array<{
+    containerName: string
+    condition: string
+  }>
   envVars?: KeyValuePairs
   cpu: 256 | 512 | 1024 | 2048 | 4096
   memory: 512 | 1024 | 2048 | 3072 | 4096 | 5120 | 6144 | 7168 | 8192 | 12_288 | 16_384
@@ -9,6 +13,7 @@ export interface ConfigurationTaskDefinition {
     keys: string[]
   }>
   ports?: number[]
+  siblingContainers?: string[]
   taskRoleArn?: string
   executionRoleArn: string
   subnet: 'public' | 'private'


### PR DESCRIPTION
Usage example where a 2nd process is launched within each task that runs Rails; in this example, the open telemetry collector for AWS XRay.

Patched that in as alpha-1 to the 0.8.x release, let me know if any other version should be used for that.

```yml
# ecsx.yml

tasks:
  $rails: &rails
    <<: *default
    envVars:
      PORT: "3000"
      RAILS_MAX_THREADS: "4"
    secrets:
      - name: app
        keys:
          - RAILS_MASTER_KEY
          - DATABASE_URL_MASTER
  aws_otel_collector:
    image: "amazon/aws-otel-collector:v0.20.0"
    command:
      - --config=/etc/ecs/ecs-default-config.yaml


  web:
    <<: *rails
    command:
      - bundle
      - exec
      - puma
    siblingContainers:
      - aws_otel_collector
    dependsOn:
      - containerName: "aws_otel_collector"
        condition: "START"
```