### PR TITLE
clusterName is not required globally

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,6 @@ export class Config {
       'region',
       'accountId',
       'project',
-      'clusterName',
     ]
     for (const key of requiredVariables) {
       const value = combinedVariables[key] || undefined


### PR DESCRIPTION
Running `ecsx list-clusters` complains about `clusterName` not being defined which is a bug,