### PR TITLE
Run depdedupe on CI

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
+      - run: npx depdedupe
       - run: yarn install
       - run: yarn lint
       - run: yarn build


### PR DESCRIPTION
This ensures compatible versions of dependencies are always installed once.