### PR TITLE
Upgrade tty-table from 4.2.3 to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "js-yaml": "^4.1.1",
     "jsonschema": "^1.5.0",
     "tslib": "^2.8.1",
-    "tty-table": "^4.2.3"
+    "tty-table": "^5.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       tty-table:
-        specifier: ^4.2.3
-        version: 4.2.3
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12
@@ -3481,8 +3481,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tty-table@4.2.3:
-    resolution: {integrity: sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==}
+  tty-table@5.0.0:
+    resolution: {integrity: sha512-WhUmYKqKIGu0pGNAHxSE6hYEatb274MdmynDsNVIpRjfK/aT47cVuWTFkB09wTnZfIY9h4NcjYMvWD0VHzJkjQ==}
     engines: {node: '>=8.0.0'}
     hasBin: true
 
@@ -8244,7 +8244,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tty-table@4.2.3:
+  tty-table@5.0.0:
     dependencies:
       chalk: 4.1.2
       csv: 5.5.3


### PR DESCRIPTION
## Package Updates

- tty-table: [4.2.3 -> 5.0.0](https://github.com/tecfu/tty-table/releases/tag/v5.0.0)
  - Breaking: `null`/`undefined` cells now render as empty string (`""`) instead of a colored `?`
  - Fixed column width coercion to integers
  - Fixed data parsing to wait for complete standard input before processing

## Code Changes

No code modifications required. The existing usage in `src/commands/ps.ts` already uses `|| ''` fallbacks for most fields, and the new empty-string default for missing cells produces cleaner output that matches the tool's style.

## Checks

- Checked changelog/release notes for breaking changes
- Type check passes (tsc --noEmit)
- Lint passes (biome check)
- Build passes (tsc)
- All 17 tests pass