### PR TITLE
Add GitHub Actions workflow for npm publishing with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish Package to NPM
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write # Required for provenance
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.14"
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm test
+      - run: pnpm publish --no-git-checks


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` that triggers on `v*` tag pushes
- Publishes the package to npm with Node provenance (OIDC `id-token: write`)
- Runs install, build, and test before publishing

## Test plan

- [ ] Push a version tag (e.g. `git tag v0.9.1 && git push --tags`) and verify the workflow runs
- [ ] Confirm the published package shows provenance on npmjs.com