### PR TITLE
release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated to oclif v4 (#109)
+- Node 24 support (#111)
+- Upgraded all dependencies to latest versions
+- Migrate from yarn to pnpm for package management (#117)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+
+## [0.9.1] - 2026-04-17
+
 ### Changed
 
 - Updated to oclif v4 (#109)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ecsx",
   "description": "Easily create, manage and deploy ECS based applications",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Marc Qualie @marcqualie",
   "bin": {
     "ecsx": "./bin/run"


### PR DESCRIPTION
## Summary

- Bump version to v0.9.1
- Update changelog with v0.9.1 entry (2026-04-17)

## Post-merge

After merging, tag `v0.9.1` on main and create a GitHub release.