### PR TITLE
Update pnpm packageManager to 10.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.4",
   "repository": "marcqualie/ecsx",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Bumps `packageManager` in `package.json` from `pnpm@10.33.0` to `pnpm@10.33.4`.
- Verified `pnpm install` runs cleanly under the new version.

## Notable changes between 10.33.0 and 10.33.4

- **10.33.1**: Commands like `version`, `login`, `publish`, `dist-tag`, `whoami`, etc. are now handed over to the wanted pnpm when a project's `packageManager` field selects pnpm v11+, instead of being silently shelled out to npm ([#11328](https://github.com/pnpm/pnpm/issues/11328)).
- **10.33.2**: Fix globally-installed bins failing with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` when pnpm was installed via the standalone `@pnpm/exe` binary ([#11291](https://github.com/pnpm/pnpm/issues/11291), [#4645](https://github.com/pnpm/pnpm/issues/4645)). Fix an infinite fork-bomb that could happen when pnpm was installed with one version and run inside a project whose `packageManager` field selected a different version ([#11337](https://github.com/pnpm/pnpm/issues/11337)).
- **10.33.3**: `pnpm self-update` from v10's `@pnpm/exe` to v11+ on Intel macOS now transparently switches to the JS-only `pnpm` package. `pnpm self-update` no longer downgrades pnpm when the registry's `latest` dist-tag points to an older release ([#11418](https://github.com/pnpm/pnpm/issues/11418)).
- **10.33.4**: Pin the integrity of git-hosted tarballs (codeload.github.com, gitlab.com, bitbucket.org) in the lockfile so subsequent installs detect a tampered or substituted tarball. Fix a regression where `pnpm --recursive --filter '!<pkg>' run/exec/test/add` would include the workspace root in the matched projects ([#11341](https://github.com/pnpm/pnpm/issues/11341)).

## Test plan

- [x] `pnpm install` succeeds with the new version
- [ ] CI passes