### PR TITLE
Update pnpm to v11.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.0.6",
   "repository": "marcqualie/ecsx",
   "scripts": {
     "build": "tsc",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: false
+  unrs-resolver: false
+  yarn: false


### PR DESCRIPTION
## Summary
- Bumps `packageManager` from `pnpm@10.33.4` to `pnpm@11.0.6`
- v11 is published on npm under `latest-11`/`next-11` (npm `latest` still points to 10.x)
- `pnpm install` runs cleanly with no lockfile changes

## Test plan
- [x] CI passes
- [x] `pnpm install` works locally
- [x] `pnpm build` / `pnpm test` succeed