### PR TITLE
Patched minimatch from 3.1.2/5.1.2/9.0.5 to 3.1.5/5.1.9/9.0.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2630,15 +2630,15 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@5.1.2:
-    resolution: {integrity: sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
@@ -6040,7 +6040,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.2
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -6132,7 +6132,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -6142,7 +6142,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -6426,7 +6426,7 @@ snapshots:
       async: 3.2.4
       chalk: 4.1.2
       filelist: 1.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   jest-changed-files@30.4.1:
     dependencies:
@@ -6866,15 +6866,15 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.2:
+  minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.2
 
-  minimatch@9.0.5:
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.2
 
@@ -7375,7 +7375,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
 
   tiny-jsonc@1.0.2: {}
 


### PR DESCRIPTION
## Vulnerabilities

- [#71](https://github.com/marcqualie/ecsx/security/dependabot/71) [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments (>= 5.0.0, < 5.1.8)
- [#70](https://github.com/marcqualie/ecsx/security/dependabot/70) [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions (>= 5.0.0, < 5.1.8)
- [#69](https://github.com/marcqualie/ecsx/security/dependabot/69) [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments (>= 9.0.0, < 9.0.7)
- [#66](https://github.com/marcqualie/ecsx/security/dependabot/66) [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions (< 3.1.4)

## Changelog

- minimatch: [3.1.2 -> 3.1.5](https://github.com/isaacs/minimatch/compare/v3.1.2...v3.1.5)
  - Patched ReDoS vulnerability via nested extglobs (GHSA-23c5-xmqv-rm74)
- minimatch: [5.1.2 -> 5.1.9](https://github.com/isaacs/minimatch/compare/v5.1.2...v5.1.9)
  - Patched ReDoS vulnerabilities via nested extglobs and non-adjacent GLOBSTAR segments
- minimatch: [9.0.5 -> 9.0.9](https://github.com/isaacs/minimatch/compare/v9.0.5...v9.0.9)
  - Patched ReDoS vulnerabilities via nested extglobs and non-adjacent GLOBSTAR segments

## Code Changes

- No code changes needed. Transitive dependency updated via pnpm-lock.yaml only.

## Checks

- Checked changelogs for breaking changes (none, patch-level versions)
- Lint passes after upgrade
- All 31 tests across 7 suites pass after upgrade