### PR TITLE
Patched brace-expansion from 1.1.12/2.0.2/5.0.5 to 1.1.14/2.1.0/5.0.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1621,14 +1621,14 @@ packages:
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5564,16 +5564,16 @@ snapshots:
 
   bowser@2.11.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6864,19 +6864,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Vulnerabilities

- [#98](https://github.com/marcqualie/ecsx/security/dependabot/98) [CVE-2026-45149](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) brace-expansion: Large numeric range defeats documented `max` DoS protection
- [#95](https://github.com/marcqualie/ecsx/security/dependabot/95) [CVE-2026-33750](https://github.com/advisories/GHSA-f886-m6hf-6m8v) brace-expansion: Zero-step sequence causes process hang and memory exhaustion
- [#89](https://github.com/marcqualie/ecsx/security/dependabot/89) [CVE-2026-33750](https://github.com/advisories/GHSA-f886-m6hf-6m8v) brace-expansion: Zero-step sequence causes process hang and memory exhaustion

## Changelog

- brace-expansion: [1.1.12 -> 1.1.14](https://github.com/juliangruber/brace-expansion/compare/v1.1.12...v1.1.14)
  - Backport fix for GHSA-f886-m6hf-6m8v (zero-step sequence DoS)
  - Backport fix for GHSA-7h2j-956f-4vf2 with opt-in `{ max }` mitigation, removing `EXPANSION_MAX`
- brace-expansion: [2.0.2 -> 2.1.0](https://github.com/juliangruber/brace-expansion/compare/v2.0.2...v2.1.0)
  - Backport fix for GHSA-f886-m6hf-6m8v (zero-step sequence DoS)
  - Backport fix for GHSA-7h2j-956f-4vf2 with opt-in `{ max }` mitigation, removing `EXPANSION_MAX`
- brace-expansion: [5.0.5 -> 5.0.6](https://github.com/juliangruber/brace-expansion/compare/v5.0.5...v5.0.6)
  - Bump picomatch from 4.0.3 to 4.0.4

## Code Changes

- No code changes needed; brace-expansion is a transitive dependency only.

## Checks

- ✅ Checked changelogs for breaking changes (none)
- ✅ Lint passes after upgrade
- ✅ Build passes after upgrade
- ✅ All 31 tests pass after upgrade