### PR TITLE
Patched picomatch from 2.3.1/4.0.3 to 2.3.2/4.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2885,13 +2885,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -5466,7 +5462,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -6030,9 +6026,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.4.6(picomatch@4.0.3):
+  fdir@6.4.6(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6556,7 +6552,7 @@ snapshots:
       jest-regex-util: 30.4.0
       jest-util: 30.4.1
       jest-worker: 30.4.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -6600,7 +6596,7 @@ snapshots:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       jest-util: 30.4.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -6730,7 +6726,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-util@30.4.1:
     dependencies:
@@ -6739,7 +6735,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@30.4.1:
     dependencies:
@@ -6854,7 +6850,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-fn@2.1.0: {}
 
@@ -7058,9 +7054,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -7381,8 +7375,8 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.4.6(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
## Vulnerabilities

- [#80](https://github.com/marcqualie/ecsx/security/dependabot/80) [CVE-2026-33671](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) Picomatch has a ReDoS vulnerability via extglob quantifiers (high)
- [#81](https://github.com/marcqualie/ecsx/security/dependabot/81) [CVE-2026-33672](https://github.com/advisories/GHSA-3v7f-55p6-f55p) Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching (medium)
- [#78](https://github.com/marcqualie/ecsx/security/dependabot/78) [CVE-2026-33672](https://github.com/advisories/GHSA-3v7f-55p6-f55p) Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching (medium)

## Changelog

- picomatch: [2.3.1 -> 2.3.2](https://github.com/micromatch/picomatch/compare/2.3.1...2.3.2)
  - Security release fixing CVE-2026-33671 (ReDoS via extglob quantifiers) and CVE-2026-33672 (Method Injection in POSIX Character Classes)
  - Fix exception when glob pattern contains constructor
- picomatch: [4.0.3 -> 4.0.4](https://github.com/micromatch/picomatch/compare/4.0.3...4.0.4)
  - Security release fixing CVE-2026-33671 (ReDoS via extglob quantifiers) and CVE-2026-33672 (Method Injection in POSIX Character Classes)

## Code Changes

- No code changes needed; transitive dependency only (pulled via @oclif/core, jest, oclif, etc.)

## Checks

- Checked changelogs for breaking changes (none, security patch only)
- Lint passes after upgrade
- Build passes after upgrade
- All 31 tests pass after upgrade