### PR TITLE
Patched js-yaml from 3.14.1 to 3.14.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2327,8 +2327,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4267,7 +4267,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -6130,7 +6130,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## Vulnerabilities

- [#52](https://github.com/marcqualie/ecsx/security/dependabot/52) [CVE-2025-64718](https://github.com/advisories/GHSA-mh29-5h37-fv8m) js-yaml has prototype pollution in merge (`<<`)

## Changelog

- js-yaml: [3.14.1 -> 3.14.2](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
  - Backported v4.1.1 fix to v3 (security): addresses prototype pollution vulnerability in the YAML merge (`<<`) operator

## Code Changes

- No code changes needed (transitive dev dependency via jest -> @istanbuljs/load-nyc-config)

## Checks

- ✅ Checked changelogs for breaking changes (none)
- ✅ Lint passes after upgrade
- ✅ Build passes after upgrade
- ✅ All tests pass after upgrade (31 passed)