### PR TITLE
Upgrade @types/node from 24 to 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@biomejs/biome": "^2.4.15",
     "@oclif/test": "^4.1.18",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24",
+    "@types/node": "^25",
     "jest": "^30.4.2",
     "oclif": "^4.23.7",
     "ts-jest": "^29.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.1052.0
       '@inquirer/prompts':
         specifier: ^8.4.3
-        version: 8.4.3(@types/node@24.5.2)
+        version: 8.4.3(@types/node@25.9.1)
       '@oclif/core':
         specifier: ^4.11.3
         version: 4.11.3
@@ -49,17 +49,17 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^24
-        version: 24.5.2
+        specifier: ^25
+        version: 25.9.1
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@24.5.2)
+        version: 30.4.2(@types/node@25.9.1)
       oclif:
         specifier: ^4.23.7
-        version: 4.23.7(@types/node@24.5.2)
+        version: 4.23.7(@types/node@25.9.1)
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.5.2))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1))(typescript@6.0.3)
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
@@ -1213,6 +1213,9 @@ packages:
 
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3076,6 +3079,9 @@ packages:
   undici-types@7.12.0:
     resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -3972,68 +3978,68 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.5.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/checkbox@5.1.5(@types/node@24.5.2)':
+  '@inquirer/checkbox@5.1.5(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/confirm@5.1.21(@types/node@24.5.2)':
+  '@inquirer/confirm@5.1.21(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/confirm@6.0.13(@types/node@24.5.2)':
+  '@inquirer/confirm@6.0.13(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/core@10.3.2(@types/node@24.5.2)':
+  '@inquirer/core@10.3.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/core@11.1.10(@types/node@24.5.2)':
+  '@inquirer/core@11.1.10(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 2.0.5
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
   '@inquirer/core@9.2.1':
     dependencies:
@@ -4050,50 +4056,50 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/editor@4.2.23(@types/node@24.5.2)':
+  '@inquirer/editor@4.2.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/editor@5.1.2(@types/node@24.5.2)':
+  '@inquirer/editor@5.1.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/external-editor': 3.0.0(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/external-editor': 3.0.0(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/expand@4.0.23(@types/node@24.5.2)':
+  '@inquirer/expand@4.0.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/expand@5.0.14(@types/node@24.5.2)':
+  '@inquirer/expand@5.0.14(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.5.2)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 24.5.2
-
-  '@inquirer/external-editor@3.0.0(@types/node@24.5.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
+
+  '@inquirer/external-editor@3.0.0(@types/node@25.9.1)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.9.1
 
   '@inquirer/figures@1.0.15': {}
 
@@ -4104,111 +4110,111 @@ snapshots:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
-  '@inquirer/input@4.3.1(@types/node@24.5.2)':
+  '@inquirer/input@4.3.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/input@5.0.13(@types/node@24.5.2)':
+  '@inquirer/input@5.0.13(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/number@3.0.23(@types/node@24.5.2)':
+  '@inquirer/number@3.0.23(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/number@4.0.13(@types/node@24.5.2)':
+  '@inquirer/number@4.0.13(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/password@4.0.23(@types/node@24.5.2)':
+  '@inquirer/password@4.0.23(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/password@5.0.13(@types/node@24.5.2)':
+  '@inquirer/password@5.0.13(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/prompts@7.10.1(@types/node@24.5.2)':
+  '@inquirer/prompts@7.10.1(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.5.2)
-      '@inquirer/confirm': 5.1.21(@types/node@24.5.2)
-      '@inquirer/editor': 4.2.23(@types/node@24.5.2)
-      '@inquirer/expand': 4.0.23(@types/node@24.5.2)
-      '@inquirer/input': 4.3.1(@types/node@24.5.2)
-      '@inquirer/number': 3.0.23(@types/node@24.5.2)
-      '@inquirer/password': 4.0.23(@types/node@24.5.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.5.2)
-      '@inquirer/search': 3.2.2(@types/node@24.5.2)
-      '@inquirer/select': 4.4.2(@types/node@24.5.2)
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.1)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.1)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.1)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.1)
+      '@inquirer/input': 4.3.1(@types/node@25.9.1)
+      '@inquirer/number': 3.0.23(@types/node@25.9.1)
+      '@inquirer/password': 4.0.23(@types/node@25.9.1)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.1)
+      '@inquirer/search': 3.2.2(@types/node@25.9.1)
+      '@inquirer/select': 4.4.2(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/prompts@8.4.3(@types/node@24.5.2)':
+  '@inquirer/prompts@8.4.3(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/checkbox': 5.1.5(@types/node@24.5.2)
-      '@inquirer/confirm': 6.0.13(@types/node@24.5.2)
-      '@inquirer/editor': 5.1.2(@types/node@24.5.2)
-      '@inquirer/expand': 5.0.14(@types/node@24.5.2)
-      '@inquirer/input': 5.0.13(@types/node@24.5.2)
-      '@inquirer/number': 4.0.13(@types/node@24.5.2)
-      '@inquirer/password': 5.0.13(@types/node@24.5.2)
-      '@inquirer/rawlist': 5.2.9(@types/node@24.5.2)
-      '@inquirer/search': 4.1.9(@types/node@24.5.2)
-      '@inquirer/select': 5.1.5(@types/node@24.5.2)
+      '@inquirer/checkbox': 5.1.5(@types/node@25.9.1)
+      '@inquirer/confirm': 6.0.13(@types/node@25.9.1)
+      '@inquirer/editor': 5.1.2(@types/node@25.9.1)
+      '@inquirer/expand': 5.0.14(@types/node@25.9.1)
+      '@inquirer/input': 5.0.13(@types/node@25.9.1)
+      '@inquirer/number': 4.0.13(@types/node@25.9.1)
+      '@inquirer/password': 5.0.13(@types/node@25.9.1)
+      '@inquirer/rawlist': 5.2.9(@types/node@25.9.1)
+      '@inquirer/search': 4.1.9(@types/node@25.9.1)
+      '@inquirer/select': 5.1.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/rawlist@4.1.11(@types/node@24.5.2)':
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/rawlist@5.2.9(@types/node@24.5.2)':
+  '@inquirer/rawlist@5.2.9(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/search@3.2.2(@types/node@24.5.2)':
+  '@inquirer/search@3.2.2(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/search@4.1.9(@types/node@24.5.2)':
+  '@inquirer/search@4.1.9(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
   '@inquirer/select@2.5.0':
     dependencies:
@@ -4218,24 +4224,24 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.3
 
-  '@inquirer/select@4.4.2(@types/node@24.5.2)':
+  '@inquirer/select@4.4.2(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.1)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.1)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/select@5.1.5(@types/node@24.5.2)':
+  '@inquirer/select@5.1.5(@types/node@25.9.1)':
     dependencies:
       '@inquirer/ansi': 2.0.5
-      '@inquirer/core': 11.1.10(@types/node@24.5.2)
+      '@inquirer/core': 11.1.10(@types/node@25.9.1)
       '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@24.5.2)
+      '@inquirer/type': 4.0.5(@types/node@25.9.1)
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
   '@inquirer/type@1.5.5':
     dependencies:
@@ -4245,13 +4251,13 @@ snapshots:
     dependencies:
       mute-stream: 1.0.0
 
-  '@inquirer/type@3.0.10(@types/node@24.5.2)':
+  '@inquirer/type@3.0.10(@types/node@25.9.1)':
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
-  '@inquirer/type@4.0.5(@types/node@24.5.2)':
+  '@inquirer/type@4.0.5(@types/node@25.9.1)':
     optionalDependencies:
-      '@types/node': 24.5.2
+      '@types/node': 25.9.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4544,9 +4550,9 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.0
 
-  '@oclif/plugin-not-found@3.2.86(@types/node@24.5.2)':
+  '@oclif/plugin-not-found@3.2.86(@types/node@25.9.1)':
     dependencies:
-      '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
+      '@inquirer/prompts': 7.10.1(@types/node@25.9.1)
       '@oclif/core': 4.11.3
       ansis: 3.17.0
       fast-levenshtein: 3.0.0
@@ -4727,6 +4733,10 @@ snapshots:
   '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5806,7 +5816,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@24.5.2):
+  jest-cli@30.4.2(@types/node@25.9.1):
     dependencies:
       '@jest/core': 30.4.2
       '@jest/test-result': 30.4.1
@@ -5814,7 +5824,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@24.5.2)
+      jest-config: 30.4.2(@types/node@25.9.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -5852,6 +5862,37 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.5.2
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.4.2(@types/node@25.9.1):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.28.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6115,12 +6156,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@24.5.2):
+  jest@30.4.2(@types/node@25.9.1):
     dependencies:
       '@jest/core': 30.4.2
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@24.5.2)
+      jest-cli: 30.4.2(@types/node@25.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6295,7 +6336,7 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  oclif@4.23.7(@types/node@24.5.2):
+  oclif@4.23.7(@types/node@25.9.1):
     dependencies:
       '@aws-sdk/client-cloudfront': 3.1052.0
       '@aws-sdk/client-s3': 3.1051.0
@@ -6304,7 +6345,7 @@ snapshots:
       '@inquirer/select': 2.5.0
       '@oclif/core': 4.11.3
       '@oclif/plugin-help': 6.2.49
-      '@oclif/plugin-not-found': 3.2.86(@types/node@24.5.2)
+      '@oclif/plugin-not-found': 3.2.86(@types/node@25.9.1)
       '@oclif/plugin-warn-if-update-available': 3.1.60
       ansis: 3.17.0
       async-retry: 1.3.3
@@ -6734,12 +6775,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-jest@29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.5.2))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@24.5.2)
+      jest: 30.4.2(@types/node@25.9.1)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -6830,6 +6871,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.12.0: {}
+
+  undici-types@7.24.6: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Package Updates

- @types/node: [24.5.2 -> 25.9.1](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/master/types/node)
  - Tracks Node.js 25 type definitions
  - Removed types: `SlowBuffer`, `assert.CallTracker`, `fs.F_OK/R_OK/W_OK/X_OK` constants
  - New global types: `ErrorEvent`, `localStorage`, `sessionStorage`
  - V8 upgraded to 14.1 (NODE_MODULE_VERSION 141)

## Code Changes

No code modifications required - none of the removed APIs (SlowBuffer, fs.F_OK/R_OK/W_OK/X_OK, CallTracker, writeHeader) are used in this project.

## Checks

- ✅ Checked changelogs for breaking changes
- ✅ Type check passes (`pnpm check-types`)
- ✅ Lint passes (`pnpm lint`)
- ✅ All 31 tests pass (`pnpm test`)
- ✅ No code modifications were necessary