### PR TITLE
Add essential and containerMemory task params

### DIFF
--- a/src/ecs/task-definition.ts
+++ b/src/ecs/task-definition.ts
@@ -125,11 +125,12 @@ const containerDefinitionFromConfiguration = (
     name: taskName,
     image: taskConfig.image,
     command: taskConfig.command,
+    memory: taskConfig.containerMemory,
     portMappings: portMappingsFromConfiguration(taskConfig),
     environment: environmentFromEnvVars(envVars),
     secrets: secretsFromConfiguration(taskName, clusterName, config, region),
     logConfiguration: logConfigurationFromConfiguration(taskName, variables),
-    essential: true,
+    essential: taskConfig.essential ?? true,
     readonlyRootFilesystem: false,
     dependsOn: taskConfig.dependsOn?.map((dep) => ({
       containerName: dep.containerName,

--- a/src/schema.json
+++ b/src/schema.json
@@ -171,6 +171,15 @@
           "memory": {
             "type": "integer"
           },
+          "containerMemory": {
+            "type": "integer",
+            "description": "Hard memory limit (MiB) for this container. Useful for capping individual containers within a multi-container (sibling) task."
+          },
+          "essential": {
+            "type": "boolean",
+            "default": true,
+            "description": "If true, the whole task stops when this container stops. Set false for sidecars that may exit independently. At least one container per task must be essential."
+          },
           "command": {
             "type": "array",
             "items": {

--- a/src/types/configuration.ts
+++ b/src/types/configuration.ts
@@ -19,6 +19,8 @@ export interface ConfigurationTaskDefinition {
     | 8192
     | 12_288
     | 16_384
+  containerMemory?: number
+  essential?: boolean
   secrets?: Array<{
     name: string
     keys: string[]

--- a/test/ecs/task-definition.test.ts
+++ b/test/ecs/task-definition.test.ts
@@ -1,9 +1,29 @@
 
-import { secretsFromConfiguration } from '../../src/ecs/task-definition'
+import { secretsFromConfiguration, taskDefinitionfromConfiguration } from '../../src/ecs/task-definition'
 import { configWithVariables } from '../../src/utils/config-with-variables'
 
 describe('ecs', () => {
   describe('task-definition', () => {
+    describe('taskDefinitionfromConfiguration', () => {
+      const clusterName = 'ecsx-test-cluster'
+
+      it('defaults essential to true and omits container memory', () => {
+        const { config, variables } = configWithVariables({ clusterKey: clusterName })
+        const output = taskDefinitionfromConfiguration({ clusterName, taskName: 'web', variables, config, envVars: {} })
+        const [container] = output.containerDefinitions ?? []
+        expect(container.essential).toBe(true)
+        expect(container.memory).toBeUndefined()
+      })
+
+      it('passes through essential and containerMemory when configured', () => {
+        const { config, variables } = configWithVariables({ clusterKey: clusterName })
+        const output = taskDefinitionfromConfiguration({ clusterName, taskName: 'sidecar', variables, config, envVars: {} })
+        const [container] = output.containerDefinitions ?? []
+        expect(container.essential).toBe(false)
+        expect(container.memory).toBe(256)
+      })
+    })
+
     describe('secretsFromConfiguration', () => {
       it('translate secrets to task definition format', () => {
         const { config, variables: { region } } = configWithVariables({ clusterKey: 'ecsx-test-cluster' })

--- a/test/ecsx.yml
+++ b/test/ecsx.yml
@@ -88,3 +88,15 @@ tasks:
       CLUSTER_NAME: "{{ clusterName }}"
     subnet: private
     secrets: []
+  sidecar:
+    taskRoleArn: 'somerole'
+    executionRoleArn: 'somerole'
+    image: ''
+    command: []
+    cpu: 256
+    memory: 512
+    service: false
+    essential: false
+    containerMemory: 256
+    subnet: private
+    secrets: []


### PR DESCRIPTION
## Summary

Adds two optional, additive task-definition params:

- **`essential`** (default `true`) — maps to the ECS container `essential` flag. When `false`, the container can stop/exit without taking down the whole task. Previously this was hardcoded to `true`. Primary use case is sidecar/sibling containers (`siblingContainers`) that shouldn't be load-bearing.
- **`containerMemory`** — a hard memory limit (MiB) for an individual container, mapped to the ECS container `memory` field. Useful for capping each container within a multi-container task so a sidecar can't starve the main process. The task-level `memory` (shared pool) is unchanged.

## Backwards compatibility

Both fields are optional and default to current behaviour — existing configs produce byte-identical task definitions (`essential` stays `true`, no per-container `memory` is set).

## Notes / scope

This is a clean reimplementation of the genuinely useful parts of #85 on top of current `main`. Most of that PR (`siblingContainers`, `dependsOn`, the multi-container `taskDefinitionfromConfiguration` refactor) has since landed independently, leaving it conflicting and stale. This PR deliberately **excludes** two changes from #85:

- Making `executionRoleArn` / `taskRoleArn` non-required in the schema — that loosens validation, contradicts the TS type, and trades an upfront config error for a cryptic late AWS failure.
- The `.github/CODEOWNERS` file pointing at an external org.

## Tests

Added coverage for `taskDefinitionfromConfiguration` verifying the `essential` default and the explicit `essential: false` / `containerMemory` pass-through. Full suite (33 tests), lint, and build all pass.

Closes #85