### PR TITLE
Use staged npm publishing in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm test
-      - run: pnpm publish --no-git-checks
+      - run: pnpm stage publish --no-git-checks --provenance

--- a/README.md
+++ b/README.md
@@ -303,7 +303,18 @@ Then, manually bump version in `package.json`. Once the version is updated:
 ```shell
 pnpm oclif readme # updates the readme with new version
 git commit -am "release v1.2.3"
+# create a pull request with the version bump
+# once merged you can tage the commit on main to release
 git tag v1.2.3
-git push && git push --tags
-npm publish
+git push && git push origin v1.2.3
 ```
+
+Pushing the `v*` tag triggers the [publish workflow](./.github/workflows/publish.yml),
+which builds, tests and then **stages** the release to npm via trusted publishing
+(OIDC) rather than publishing it directly.
+
+The staged release is not live yet. A maintainer must review and approve it with
+2FA before it becomes available:
+
+See the
+[npm staged publishing docs](https://docs.npmjs.com/staged-publishing) for full details.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "packageManager": "pnpm@11.0.6",
+  "packageManager": "pnpm@11.5.1",
   "repository": "marcqualie/ecsx",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Switches the release workflow from direct publish to npm staged publishing for an extra layer of protection against automated CI injection attacks.

- `pnpm stage publish` (with `--provenance`) instead of `pnpm publish`
- Bumped pinned pnpm to `11.5.1` (`pnpm stage` requires >= 11.3.0)
- Documented the review/approve step in the README

Releases now require a maintainer to review and approve the staged package with 2FA before it goes live.

Closes #151